### PR TITLE
 fix!: change the default cluster issuer, remove the namespace variable and hardcode the Helm release name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,11 +59,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -78,14 +78,6 @@ The following resources are used by this module:
 === Optional Inputs
 
 The following input variables are optional (have default values):
-
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
 
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
@@ -118,14 +110,6 @@ Description: Override of target revision of the application chart.
 Type: `string`
 
 Default: `"v1.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-system"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -205,9 +189,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -227,12 +211,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -255,12 +233,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Override of target revision of the application chart.
 |`string`
 |`"v1.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-system"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "metrics-server-${var.destination_cluster}" : "metrics-server"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -40,7 +37,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "metrics-server-${var.destination_cluster}" : "metrics-server"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "metrics-server"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "kube-system"
     }
 
     orphaned_resources {
@@ -69,7 +69,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "kube-system"
     }
 
     sync_policy {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,8 @@ resource "argocd_application" "this" {
       path            = "charts/metrics-server"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "metrics-server"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,12 +32,6 @@ variable "target_revision" {
   default     = "v1.0.0" # x-release-please-version
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "kube-system"
-}
-
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 ## Standard variables
 #######################
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string


### PR DESCRIPTION
## Description of the changes

The main changes of this PR are the following:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)